### PR TITLE
Undesirable character encoding, and Duplicate project references.

### DIFF
--- a/Kinovea.ScreenManager/Metadata/Magnifier.cs
+++ b/Kinovea.ScreenManager/Metadata/Magnifier.cs
@@ -30,7 +30,7 @@ namespace Kinovea.ScreenManager
     /// <summary>
     /// Picture-in-picture with magnification.
     /// </summary>
-    public class Magnifier : ITrackable
+    public class Magnifier : ITrackable
     {
         // TODO: save positions in the KVA.
         // TODO: support for rendering unscaled.

--- a/Kinovea.ScreenManager/ScreenManager.cs
+++ b/Kinovea.ScreenManager/ScreenManager.cs
@@ -1512,11 +1512,11 @@ namespace Kinovea.ScreenManager
             mnuImportImage.Text = ScreenManagerLang.mnuImportImage;
             mnuTestGrid.Text = ScreenManagerLang.DrawingName_TestGrid;
             mnuCoordinateAxis.Text = ScreenManagerLang.mnuCoordinateSystem;
-            mnuCameraCalibration.Text = ScreenManagerLang.dlgCameraCalibration_Title + "…";
-            mnuScatterDiagram.Text = ScreenManagerLang.DataAnalysis_ScatterDiagram + "…";
-            mnuTrajectoryAnalysis.Text = ScreenManagerLang.DataAnalysis_LinearKinematics + "…";
-            mnuAngularAnalysis.Text = ScreenManagerLang.DataAnalysis_AngularKinematics + "…";
-            mnuAngleAngleAnalysis.Text = ScreenManagerLang.DataAnalysis_AngleAngleDiagrams + "…";
+            mnuCameraCalibration.Text = ScreenManagerLang.dlgCameraCalibration_Title + ".";
+            mnuScatterDiagram.Text = ScreenManagerLang.DataAnalysis_ScatterDiagram + ".";
+            mnuTrajectoryAnalysis.Text = ScreenManagerLang.DataAnalysis_LinearKinematics + ".";
+            mnuAngularAnalysis.Text = ScreenManagerLang.DataAnalysis_AngularKinematics + ".";
+            mnuAngleAngleAnalysis.Text = ScreenManagerLang.DataAnalysis_AngleAngleDiagrams + ".";
         }
             
         private void RefreshCultureMenuFilters()

--- a/Kinovea.ScreenManager/Thumbnails/ThumbnailFile.cs
+++ b/Kinovea.ScreenManager/Thumbnails/ThumbnailFile.cs
@@ -459,7 +459,7 @@ namespace Kinovea.ScreenManager
 
             if (ShouldShowProperty(FileProperty.Duration))
             {
-                string duration = m_bIsImage ? ScreenManagerLang.Generic_Image + " " : details.Details[FileProperty.Duration];
+                string duration = m_bIsImage ? ScreenManagerLang.Generic_Image + " " : details.Details[FileProperty.Duration];
                 DrawPropertyString(canvas, duration, top);
                 top += verticalMargin;
             }
@@ -718,7 +718,7 @@ namespace Kinovea.ScreenManager
 
                 }
 
-                lblFileName.Text = fits ? text : text + "…";
+                lblFileName.Text = fits ? text : text + ".";
             }
             catch
             {

--- a/Kinovea/Kinovea.csproj
+++ b/Kinovea/Kinovea.csproj
@@ -387,10 +387,6 @@
       <Name>Kinovea.Camera.HTTP</Name>
     </ProjectReference>
     <ProjectReference Include="..\Kinovea.Camera\Kinovea.Camera.csproj">
-      <Project>7EC5DEBF-DF52-40F5-A9FE-1B2007B6116D</Project>
-      <Name>Kinovea.Camera</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Kinovea.Camera\Kinovea.Camera.csproj">
       <Project>{2bf373b8-5d33-4fcf-8c30-5e8caf6777e7}</Project>
       <Name>Kinovea.Camera</Name>
     </ProjectReference>


### PR DESCRIPTION
There are some character encodings that cannot be interconverted, so the build cannot be done in my environment.

- nbsp(0xA0) -> 0x20
- hellip(0x85) -> 0x2E

Duplicated ProjectReference (Kinovea.Camera.csproj)

- 7EC5DEBF-DF52-40F5-A9FE-1B2007B6116D
- {2bf373b8-5d33-4fcf-8c30-5e8caf6777e7}