### PR TITLE
Corrected non-ascii charactors to ascii charactors.

### DIFF
--- a/Kinovea.ScreenManager/Metadata/Magnifier.cs
+++ b/Kinovea.ScreenManager/Metadata/Magnifier.cs
@@ -1,6 +1,6 @@
 #region License
 /*
-Copyright © Joan Charmant 2012.
+Copyright ï½© Joan Charmant 2012.
 jcharmant@gmail.com 
  
 This file is part of Kinovea.
@@ -30,7 +30,7 @@ namespace Kinovea.ScreenManager
     /// <summary>
     /// Picture-in-picture with magnification.
     /// </summary>
-    public class Magnifier : ITrackable
+    public class Magnifier : ITrackable
     {
         // TODO: save positions in the KVA.
         // TODO: support for rendering unscaled.

--- a/Kinovea.ScreenManager/ScreenManager.cs
+++ b/Kinovea.ScreenManager/ScreenManager.cs
@@ -1,6 +1,6 @@
 #region License
 /*
-Copyright © Joan Charmant 2008.
+Copyright ÔΩ© Joan Charmant 2008.
 jcharmant@gmail.com 
  
 This file is part of Kinovea.
@@ -1286,15 +1286,15 @@ namespace Kinovea.ScreenManager
                         else
                         {
                             // Ecran de droite en lecture, avec rien dedans.
-                            // Si l'Ècran de gauche Ètait Ègalement vide, bEmpty reste ‡ true.
-                            // Si l'Ècran de gauche Ètait plein, bEmpty reste ‡ false.
+                            // Si l'È¶óran de gauche È®Åait È¶Æalement vide, bEmpty reste „Éªtrue.
+                            // Si l'È¶óran de gauche È®Åait plein, bEmpty reste „Éªfalse.
                         }
                     }
                     else if (screenList[1] is CaptureScreen)
                     {
                         // Ecran de droite en capture.
-                        // Si l'Ècran de gauche Ètait Ègalement vide, bEmpty reste ‡ true.
-                        // Si l'Ècran de gauche Ètait plein, bEmpty reste ‡ false.
+                        // Si l'È¶óran de gauche È®Åait È¶Æalement vide, bEmpty reste „Éªtrue.
+                        // Si l'È¶óran de gauche È®Åait plein, bEmpty reste „Éªfalse.
                     }
                     break;
 
@@ -1506,11 +1506,11 @@ namespace Kinovea.ScreenManager
             mnuImportImage.Text = ScreenManagerLang.mnuImportImage;
             mnuTestGrid.Text = ScreenManagerLang.DrawingName_TestGrid;
             mnuCoordinateAxis.Text = ScreenManagerLang.mnuCoordinateSystem;
-            mnuCameraCalibration.Text = ScreenManagerLang.dlgCameraCalibration_Title + "Ö";
-            mnuScatterDiagram.Text = ScreenManagerLang.DataAnalysis_ScatterDiagram + "Ö";
-            mnuTrajectoryAnalysis.Text = ScreenManagerLang.DataAnalysis_LinearKinematics + "Ö";
-            mnuAngularAnalysis.Text = ScreenManagerLang.DataAnalysis_AngularKinematics + "Ö";
-            mnuAngleAngleAnalysis.Text = ScreenManagerLang.DataAnalysis_AngleAngleDiagrams + "Ö";
+            mnuCameraCalibration.Text = ScreenManagerLang.dlgCameraCalibration_Title + "...";
+            mnuScatterDiagram.Text = ScreenManagerLang.DataAnalysis_ScatterDiagram + "...";
+            mnuTrajectoryAnalysis.Text = ScreenManagerLang.DataAnalysis_LinearKinematics + "...";
+            mnuAngularAnalysis.Text = ScreenManagerLang.DataAnalysis_AngularKinematics + "...";
+            mnuAngleAngleAnalysis.Text = ScreenManagerLang.DataAnalysis_AngleAngleDiagrams + "...";
         }
             
         private void RefreshCultureMenuFilters()

--- a/Kinovea.ScreenManager/Thumbnails/ThumbnailFile.cs
+++ b/Kinovea.ScreenManager/Thumbnails/ThumbnailFile.cs
@@ -1,5 +1,5 @@
 /*
-Copyright © Joan Charmant 2008.
+Copyright ï½© Joan Charmant 2008.
 jcharmant@gmail.com 
  
 This file is part of Kinovea.
@@ -227,7 +227,7 @@ namespace Kinovea.ScreenManager
                 if (summary.ImageSize == Size.Empty)
                     details.Details[FileProperty.Size] = "";
                 else
-                    details.Details[FileProperty.Size] = string.Format("{0}×{1}", summary.ImageSize.Width, summary.ImageSize.Height);
+                    details.Details[FileProperty.Size] = string.Format("{0}:{1}", summary.ImageSize.Width, summary.ImageSize.Height);
                 
                 hasKva = summary.HasKva;
                 if (hasKva)
@@ -459,7 +459,7 @@ namespace Kinovea.ScreenManager
 
             if (ShouldShowProperty(FileProperty.Duration))
             {
-                string duration = m_bIsImage ? ScreenManagerLang.Generic_Image + " " : details.Details[FileProperty.Duration];
+                string duration = m_bIsImage ? ScreenManagerLang.Generic_Image + "..." : details.Details[FileProperty.Duration];
                 DrawPropertyString(canvas, duration, top);
                 top += verticalMargin;
             }
@@ -718,7 +718,7 @@ namespace Kinovea.ScreenManager
 
                 }
 
-                lblFileName.Text = fits ? text : text + "…";
+                lblFileName.Text = fits ? text : text + "...";
             }
             catch
             {

--- a/Tools/XML/Kva to Spreadsheets/kva2msxml-en.xsl
+++ b/Tools/XML/Kva to Spreadsheets/kva2msxml-en.xsl
@@ -261,7 +261,7 @@
   </Row>
   <Row>
     <Cell ss:StyleID="header"><Data ss:Type="String">Name</Data></Cell>
-    <Cell ss:StyleID="header"><Data ss:Type="String">Value (�)</Data></Cell>
+    <Cell ss:StyleID="header"><Data ss:Type="String">Value</Data></Cell>
     <Cell ss:StyleID="header"><Data ss:Type="String">Time</Data></Cell>
   </Row>
   <xsl:for-each select="Keyframe/Drawings/Angle/Measure">


### PR DESCRIPTION
Replace non-ASCII characters with ASCII characters because Visual Studio 2019 in a Japanese environment will not open the file properly and the build will fail.

- hellip(0x85) -> 0x2E
- nbsp(0xA0) -> 0x20

and so on.