### PR TITLE
New encoding: Unicode (UTF-8 with signature) - Codepage 65001

### DIFF
--- a/Kinovea.ScreenManager/ScreenManager.cs
+++ b/Kinovea.ScreenManager/ScreenManager.cs
@@ -1,6 +1,6 @@
-#region License
+ï»¿#region License
 /*
-Copyright © Joan Charmant 2008.
+Copyright Â© Joan Charmant 2008.
 jcharmant@gmail.com 
  
 This file is part of Kinovea.
@@ -1504,11 +1504,11 @@ namespace Kinovea.ScreenManager
             mnuImportImage.Text = ScreenManagerLang.mnuImportImage;
             mnuTestGrid.Text = ScreenManagerLang.DrawingName_TestGrid;
             mnuCoordinateAxis.Text = ScreenManagerLang.mnuCoordinateSystem;
-            mnuCameraCalibration.Text = ScreenManagerLang.dlgCameraCalibration_Title + "…";
-            mnuScatterDiagram.Text = ScreenManagerLang.DataAnalysis_ScatterDiagram + "…";
-            mnuTrajectoryAnalysis.Text = ScreenManagerLang.DataAnalysis_LinearKinematics + "…";
-            mnuAngularAnalysis.Text = ScreenManagerLang.DataAnalysis_AngularKinematics + "…";
-            mnuAngleAngleAnalysis.Text = ScreenManagerLang.DataAnalysis_AngleAngleDiagrams + "…";
+            mnuCameraCalibration.Text = ScreenManagerLang.dlgCameraCalibration_Title + "â€¦";
+            mnuScatterDiagram.Text = ScreenManagerLang.DataAnalysis_ScatterDiagram + "â€¦";
+            mnuTrajectoryAnalysis.Text = ScreenManagerLang.DataAnalysis_LinearKinematics + "â€¦";
+            mnuAngularAnalysis.Text = ScreenManagerLang.DataAnalysis_AngularKinematics + "â€¦";
+            mnuAngleAngleAnalysis.Text = ScreenManagerLang.DataAnalysis_AngleAngleDiagrams + "â€¦";
         }
             
         private void RefreshCultureMenuFilters()

--- a/Kinovea.ScreenManager/Thumbnails/ThumbnailFile.cs
+++ b/Kinovea.ScreenManager/Thumbnails/ThumbnailFile.cs
@@ -1,5 +1,5 @@
-/*
-Copyright © Joan Charmant 2008.
+ï»¿/*
+Copyright Â© Joan Charmant 2008.
 jcharmant@gmail.com 
  
 This file is part of Kinovea.
@@ -227,7 +227,7 @@ namespace Kinovea.ScreenManager
                 if (summary.ImageSize == Size.Empty)
                     details.Details[FileProperty.Size] = "";
                 else
-                    details.Details[FileProperty.Size] = string.Format("{0}×{1}", summary.ImageSize.Width, summary.ImageSize.Height);
+                    details.Details[FileProperty.Size] = string.Format("{0}Ã—{1}", summary.ImageSize.Width, summary.ImageSize.Height);
                 
                 hasKva = summary.HasKva;
                 if (hasKva)
@@ -459,7 +459,7 @@ namespace Kinovea.ScreenManager
 
             if (ShouldShowProperty(FileProperty.Duration))
             {
-                string duration = m_bIsImage ? ScreenManagerLang.Generic_Image + " " : details.Details[FileProperty.Duration];
+                string duration = m_bIsImage ? ScreenManagerLang.Generic_Image + "Â " : details.Details[FileProperty.Duration];
                 DrawPropertyString(canvas, duration, top);
                 top += verticalMargin;
             }
@@ -718,7 +718,7 @@ namespace Kinovea.ScreenManager
 
                 }
 
-                lblFileName.Text = fits ? text : text + "…";
+                lblFileName.Text = fits ? text : text + "â€¦";
             }
             catch
             {


### PR DESCRIPTION
Old encoding: Western European (Windows) - Codepage 1252

The following file contains non-ascii characters, which will cause build errors in Japanese VS2019:

- ScreenManager.cs
- ThumbnailFile.cs

So, the encoding of these files is changed to UTF-8 with BOM.