### PR TITLE
Camera.GenICam: remove hardcoded AppData path

### DIFF
--- a/Kinovea.Camera.GenICam/Kinovea.Camera.GenICam.csproj
+++ b/Kinovea.Camera.GenICam/Kinovea.Camera.GenICam.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>C:\Users\joan\AppData\Roaming\Kinovea\Plugins\Camera\GenICam\</OutputPath>
+    <OutputPath>%AppData%\Kinovea\Plugins\Camera\GenICam\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>


### PR DESCRIPTION
I had to remove this hardcoded path to get Kinovea to compile locally.