### PR TITLE
Angle Values Calculation Added into TrackabilityManager.CollectMeasuredData()

### DIFF
--- a/Kinovea.ScreenManager/Exporters/Spreadsheet/ExporterODS.cs
+++ b/Kinovea.ScreenManager/Exporters/Spreadsheet/ExporterODS.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Serialization;
 using System.Xml.Xsl;
+using DocumentFormat.OpenXml.Drawing.Diagrams;
 using ICSharpCode.SharpZipLib.Zip;
 using Kinovea.Services;
 
@@ -519,7 +520,14 @@ namespace Kinovea.ScreenManager
             {
                 // Write the main header.
                 w.WriteStartElement("table:table-row");
-                WriteCell(w, timeline.Name, "trackHeader", timeline.Data.Keys.Count * 2 + 1);
+                if (timeline.Data.Count == 3 && timeline.AngleValues != null) //only show angle values column if timeline is using 3 point angle markers and anglue values is not null
+                {
+                    WriteCell(w, timeline.Name, "trackHeader", timeline.Data.Keys.Count * 2 + 2);
+                }
+                else
+                {
+                    WriteCell(w, timeline.Name, "trackHeader", timeline.Data.Keys.Count * 2 + 1);
+                }
                 w.WriteEndElement();
 
                 // Write second row of headers: point names.
@@ -529,6 +537,10 @@ namespace Kinovea.ScreenManager
                 foreach (var pointName in timeline.Data.Keys)
                 {
                     WriteCell(w, pointName, "valueHeader", 2);
+                    WriteCell(w, "", "valueHeader");
+                }
+                if (timeline.Data.Count == 3 && timeline.AngleValues != null) //only show angle values column if timeline is using 3 point angle markers and anglue values is not null
+                {
                     WriteCell(w, "", "valueHeader");
                 }
                 w.WriteEndElement();
@@ -541,6 +553,11 @@ namespace Kinovea.ScreenManager
                     WriteCell(w, string.Format("X ({0})", md.Units.LengthSymbol), "valueHeader");
                     WriteCell(w, string.Format("Y ({0})", md.Units.LengthSymbol), "valueHeader");
                 }
+                if (timeline.Data.Count == 3 && timeline.AngleValues != null) //only show angle values column if timeline is using 3 point angle markers and anglue values is not null
+                {
+                    WriteCell(w, string.Format("Angle ({0})", md.Units.AngleSymbol), "valueHeader");
+                }
+
                 w.WriteEndElement();
 
                 // Write data.
@@ -553,6 +570,10 @@ namespace Kinovea.ScreenManager
                     {
                         WriteCell(w, pointValues[i].X, "number");
                         WriteCell(w, pointValues[i].Y, "number");
+                    }
+                    if (timeline.Data.Count == 3 && timeline.AngleValues != null) //only show angle values if timeline is using 3 point angle markers and anglue values is not null
+                    {
+                        WriteCell(w, timeline.AngleValues[i], "number");
                     }
                     w.WriteEndElement();
                 }

--- a/Kinovea.ScreenManager/Exporters/Spreadsheet/ExporterODS.cs
+++ b/Kinovea.ScreenManager/Exporters/Spreadsheet/ExporterODS.cs
@@ -7,7 +7,6 @@ using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Serialization;
 using System.Xml.Xsl;
-using DocumentFormat.OpenXml.Drawing.Diagrams;
 using ICSharpCode.SharpZipLib.Zip;
 using Kinovea.Services;
 
@@ -520,7 +519,8 @@ namespace Kinovea.ScreenManager
             {
                 // Write the main header.
                 w.WriteStartElement("table:table-row");
-                if (timeline.Data.Count == 3 && timeline.AngleValues != null) //only show angle values column if timeline is using 3 point angle markers and anglue values is not null
+                //only show angle values column if timeline is using 3 point angle markers and anglue values is not null
+                if (timeline.Data.Count == 3 && timeline.AngleValues != null)
                 {
                     WriteCell(w, timeline.Name, "trackHeader", timeline.Data.Keys.Count * 2 + 2);
                 }
@@ -553,7 +553,8 @@ namespace Kinovea.ScreenManager
                     WriteCell(w, string.Format("X ({0})", md.Units.LengthSymbol), "valueHeader");
                     WriteCell(w, string.Format("Y ({0})", md.Units.LengthSymbol), "valueHeader");
                 }
-                if (timeline.Data.Count == 3 && timeline.AngleValues != null) //only show angle values column if timeline is using 3 point angle markers and anglue values is not null
+
+                if (timeline.Data.Count == 3 && timeline.AngleValues != null)
                 {
                     WriteCell(w, string.Format("Angle ({0})", md.Units.AngleSymbol), "valueHeader");
                 }
@@ -571,7 +572,8 @@ namespace Kinovea.ScreenManager
                         WriteCell(w, pointValues[i].X, "number");
                         WriteCell(w, pointValues[i].Y, "number");
                     }
-                    if (timeline.Data.Count == 3 && timeline.AngleValues != null) //only show angle values if timeline is using 3 point angle markers and anglue values is not null
+
+                    if (timeline.Data.Count == 3 && timeline.AngleValues != null)
                     {
                         WriteCell(w, timeline.AngleValues[i], "number");
                     }

--- a/Kinovea.ScreenManager/Metadata/Serialization/MeasuredDataTimeseries.cs
+++ b/Kinovea.ScreenManager/Metadata/Serialization/MeasuredDataTimeseries.cs
@@ -34,6 +34,11 @@ namespace Kinovea.ScreenManager
         /// This is only used for sorting for consistency of export and should not be exposed to users.
         /// </summary>
         public long FirstTimestamp { get; set; } = 0;
+
+        /// <summary>
+        /// List of pre-computed angle values.
+        /// This is only used for angle objects.
+        /// </summary>
         public List<float> AngleValues { get; set; }
     }
 }

--- a/Kinovea.ScreenManager/Metadata/Serialization/MeasuredDataTimeseries.cs
+++ b/Kinovea.ScreenManager/Metadata/Serialization/MeasuredDataTimeseries.cs
@@ -34,5 +34,6 @@ namespace Kinovea.ScreenManager
         /// This is only used for sorting for consistency of export and should not be exposed to users.
         /// </summary>
         public long FirstTimestamp { get; set; } = 0;
+        public List<float> AngleValues { get; set; }
     }
 }

--- a/Kinovea.ScreenManager/Tracking/Trackability/TrackabilityManager.cs
+++ b/Kinovea.ScreenManager/Tracking/Trackability/TrackabilityManager.cs
@@ -26,7 +26,6 @@ using System.Linq;
 using Kinovea.Video;
 using System.Xml;
 using Kinovea.Services;
-using System.Reflection;
 
 namespace Kinovea.ScreenManager
 {

--- a/Kinovea.ScreenManager/Tracking/Trackability/TrackabilityManager.cs
+++ b/Kinovea.ScreenManager/Tracking/Trackability/TrackabilityManager.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using Kinovea.Video;
 using System.Xml;
 using Kinovea.Services;
+using System.Reflection;
 
 namespace Kinovea.ScreenManager
 {
@@ -320,6 +321,64 @@ namespace Kinovea.ScreenManager
                     mdt.Data.Add(name, value);
                 }
 
+                if (drawing is DrawingAngle drawingAngle)
+                {
+                    //retrieve the angleOptions from drawing
+                    AngleOptions angleOptions = drawingAngle.AngleOptions;
+
+                    //retrieve all trackable points from drawing
+                    Dictionary<string, TrackablePoint> trackablePoints = this.GetTrackablePoints(drawingAngle);
+                    if (trackablePoints == null || trackablePoints.Count != 3) //if the number of tracked points doesn't match, skip the code
+                        continue;
+
+                    //store angle keys
+                    List<string> keys = new List<string>{"o", "a", "b"};
+
+                    //the Timeline data of each key is save to a TrackingTemplate object
+                    Timeline<TrackingTemplate> timelineO = trackablePoints[keys[0]].Timeline;
+                    Timeline<TrackingTemplate> timelineA = trackablePoints[keys[1]].Timeline;
+                    Timeline<TrackingTemplate> timelineB = trackablePoints[keys[2]].Timeline;
+
+                    //lists of TimedPoint samples from the raw timelines is created
+                    List<TimedPoint> samplesO = new List<TimedPoint>();
+                    List<TimedPoint> samplesA = new List<TimedPoint>();
+                    List<TimedPoint> samplesB = new List<TimedPoint>();
+                    //now populate each individual sample with the X & Y coordinates and timestamp with its corresponding entry
+                    foreach (var entry in timelineO.Enumerate())
+                        samplesO.Add(new TimedPoint(entry.Location.X, entry.Location.Y, entry.Time));
+                    foreach (var entry in timelineA.Enumerate())
+                        samplesA.Add(new TimedPoint(entry.Location.X, entry.Location.Y, entry.Time));
+                    foreach (var entry in timelineB.Enumerate())
+                        samplesB.Add(new TimedPoint(entry.Location.X, entry.Location.Y, entry.Time));
+
+                    //create a new FilteredTrajectory for each point and call Initialize with samples and calibration settings
+                    FilteredTrajectory trajO = new FilteredTrajectory();
+                    trajO.Initialize(samplesO, metadata.CalibrationHelper);
+                    FilteredTrajectory trajA = new FilteredTrajectory();
+                    trajA.Initialize(samplesA, metadata.CalibrationHelper);
+                    FilteredTrajectory trajB = new FilteredTrajectory();
+                    trajB.Initialize(samplesB, metadata.CalibrationHelper);
+
+                    //dictionary maps keys to their FilteredTrajectory instances
+                    Dictionary<string, FilteredTrajectory> trajs = new Dictionary<string, FilteredTrajectory>()
+                    {
+                        {"o", trajO},
+                        {"a", trajA},
+                        {"b", trajB}
+                    };
+
+                    //BuildKinematics is called and an angular position of each frame is calculated
+                    //this returns the exact same angle data that is returned when calling from dedicated angle functions
+                    AngularKinematics angularKinematics = new AngularKinematics();
+                    TimeSeriesCollection tsc = angularKinematics.BuildKinematics(trajs, angleOptions, metadata.CalibrationHelper);
+
+                    //the mdt.AngleValues is populated with the computed angular position values
+                    mdt.AngleValues = new List<float>(tsc.Length);
+                    for (int i = 0; i < tsc.Length; i++)
+                    {
+                        mdt.AngleValues.Add((float)tsc[Kinematics.AngularPosition][i]);
+                    }
+                }
                 timelines.Add(mdt);
             }
         }


### PR DESCRIPTION
This is part of my final year Computing Science Project as a BSc Data Science student at University of Stirling.

Sports department staff at the University find it frustrating angle values are not outputted alongside the timeseries data table when exporting to spreadsheet.
My patch fixes this with the following changes:

- MeasuredDataTimeseries.cs - I added the AngleValues variable to this class so as to store angle value data
- ExporterODS.cs - Additional code which inserts AngleValues and subheaders, if conditions are met.
- TrackabilityManager.cs - I have added code which, for a DrawingAngle with exactly three trackable points, retrieves its angle options and timeline data, builds filtered trajectories with calibration settings, computes the angular kinematics, and stores the resulting angular positions in mdt.AngleValues.

I have performed rigorous testing and found my angles have zero difference to the values created by existing Kinovea code shown in the graph within the Angular Kinematics tab (a screenshot of an example is attached at the bottom).

I have tried my best to edit as few files and lines of code as possible, I would not like this code to get in the way of other, more important matters in the overall Kinovea project. 

Thank you, Michael.

![Screenshot 2025-03-05 221223](https://github.com/user-attachments/assets/ee632815-33e5-40b4-b53a-9648d6513d46)